### PR TITLE
Added possibility to query all fields from a specific table

### DIFF
--- a/Sources/SQL/DataQuery/DataQueryColumn.swift
+++ b/Sources/SQL/DataQuery/DataQueryColumn.swift
@@ -2,6 +2,9 @@
 public enum DataQueryColumn {
     /// All columns, `*`.
     case all
+    
+    /// All columns of a table, `foo`.*
+    case tableAll(table: String)
 
     /// A single `DataColumn` with optional key.
     case column(DataColumn, key: String?)

--- a/Sources/SQL/Serialization/SQLSerializer+DataColumn.swift
+++ b/Sources/SQL/Serialization/SQLSerializer+DataColumn.swift
@@ -17,6 +17,9 @@ extension SQLSerializer {
     public func serialize(column: DataQueryColumn) -> String {
         switch column {
         case .all: return "*"
+        case .tableAll(let table):
+            let escapedTable = makeEscapedString(from: table)
+            return escapedTable + ".*"
         case .column(let column, let key):
             let string = serialize(column: column)
             if let key = key {

--- a/Tests/SQLTests/DataQueryTests.swift
+++ b/Tests/SQLTests/DataQueryTests.swift
@@ -22,6 +22,18 @@ final class DataQueryTests: XCTestCase {
             "SELECT `foo`.`d`, `foo`.`l` FROM `foo`"
         )
     }
+    
+    func testCustomColumnSelectAll() {
+        let select = DataQuery(table: "foo", columns: [
+            .tableAll(table: "foo")
+            ]
+        )
+        
+        XCTAssertEqual(
+            GeneralSQLSerializer.shared.serialize(query: select),
+            "SELECT `foo`.* FROM `foo`"
+        )
+    }
 
     func testSelectWithPredicates() {
         var select = DataQuery(table: "foo")


### PR DESCRIPTION
Referenced from: https://github.com/vapor/fluent/issues/471

Hi,

I'm trying to build the following query using Fluent:
```
SELECT
	events.*
FROM events
	JOIN followers ON events."userID" = followers."userID" 
WHERE followers."followerID" = 2
```
I only want all values from `event` returned. In order to achieve this I'm using the `.customSQL` function. There is however a limiting factor. The way it is currently serialized the `name` of a column is always escaped. Resulting in the following query (postgreSQL):
```
SELECT
	"events"."*"
```
which of course would lead to errors as `*` is not a column of `events`.

My suggestion is to modify `DataColumn.name` to enable either requesting all (`*`) or a custom column specified by name (which would be escaped).

Edit:

I ended up adding a case to `DataQueryColumn` as this resulted in the least impact and cleaner syntax. And I believe a non breaking change but correct me if I'm wrong.
