### PR TITLE
Support outer join

### DIFF
--- a/Sources/SQL/Serialization/SQLSerializer+Joins.swift
+++ b/Sources/SQL/Serialization/SQLSerializer+Joins.swift
@@ -7,7 +7,14 @@ extension SQLSerializer {
     /// See `SQLSerializer`.
     public func serialize(join: DataJoin) -> String {
         var statement: [String] = []
-        statement.append("JOIN")
+        
+        switch join.method {
+        case .inner:
+            statement.append("INNER JOIN")
+        case .outer:
+            statement.append("LEFT OUTER JOIN")
+        }
+        
 
         let foreignTable = makeEscapedString(from: join.foreign.table ?? "") // FIXME: this is an error
         statement.append(foreignTable)

--- a/Tests/SQLTests/DataQueryTests.swift
+++ b/Tests/SQLTests/DataQueryTests.swift
@@ -109,7 +109,23 @@ final class DataQueryTests: XCTestCase {
 
         XCTAssertEqual(
             GeneralSQLSerializer.shared.serialize(query: select),
-            "SELECT * FROM `foo` JOIN `bar` ON `foo`.`id` = `bar`.`foo_id`"
+            "SELECT * FROM `foo` INNER JOIN `bar` ON `foo`.`id` = `bar`.`foo_id`"
+        )
+    }
+    
+    func testSelectWithOuterJoins() {
+        var select = DataQuery(table: "foo")
+        
+        let joinA = DataJoin(
+            method: .outer,
+            local: DataColumn(table: "foo", name: "id"),
+            foreign: DataColumn(table: "bar", name: "foo_id")
+        )
+        select.joins.append(joinA)
+        
+        XCTAssertEqual(
+            GeneralSQLSerializer.shared.serialize(query: select),
+            "SELECT * FROM `foo` LEFT OUTER JOIN `bar` ON `foo`.`id` = `bar`.`foo_id`"
         )
     }
 
@@ -198,6 +214,7 @@ final class DataQueryTests: XCTestCase {
         ("testBasicSelectStar", testBasicSelectStar),
         ("testSelectWithPredicates", testSelectWithPredicates),
         ("testSelectWithJoins", testSelectWithJoins),
+        ("testSelectWithOuterJoins", testSelectWithOuterJoins),
         ("testSubsetEdgecases", testSubsetEdgecases),
     ]
 }


### PR DESCRIPTION
`DataJoin` has `method: DataJoinMethod` but it performs inner join even if method is `.outer`.
This PR makes outer join available.

I referred to [the implementation of fluent2](https://github.com/vapor/fluent/blob/2.5.1/Sources/Fluent/SQL/GeneralSQLSerializer.swift#L718-L735).