### PR TITLE
Fixed the case that the rhs is nil and we want it as a literal then.

### DIFF
--- a/Sources/SQL/SQLBinaryOperator.swift
+++ b/Sources/SQL/SQLBinaryOperator.swift
@@ -180,12 +180,18 @@ public enum GenericSQLBinaryOperator: SQLBinaryOperator, Equatable {
 public func == <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
     where T: SQLTable, V: Encodable, E: SQLExpression
 {
+    if rhs.isNil {
+        return E.binary(.column(.keyPath(lhs)), .equal, .literal(.null))
+    }
     return E.binary(.column(.keyPath(lhs)), .equal, .bind(.encodable(rhs)))
 }
 
 public func != <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
     where T: SQLTable, V: Encodable, E: SQLExpression
 {
+    if rhs.isNil {
+        return E.binary(.column(.keyPath(lhs)), .notEqual, .literal(.null))
+    }
     return E.binary(.column(.keyPath(lhs)), .notEqual, .bind(.encodable(rhs)))
 }
 
@@ -194,4 +200,14 @@ public func == <A, B, C, D, E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
     where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
 {
     return E.binary(.column(.keyPath(lhs)), .equal, .column(.keyPath(rhs)))
+}
+
+internal extension Encodable {
+    /// Returns `true` if this `Encodable` is `nil`.
+    var isNil: Bool {
+        guard let optional = self as? AnyOptionalType, optional.anyWrapped == nil else {
+            return false
+        }
+        return true
+    }
 }


### PR DESCRIPTION
Fixes a bug where _nil_ is not properly detected.

Referenced here:
https://github.com/vapor/fluent-mysql/issues/120
https://github.com/vapor/sql/issues/13