### PR TITLE
add CREATE and DROP index queries

### DIFF
--- a/Sources/SQL/SQLCreateIndex.swift
+++ b/Sources/SQL/SQLCreateIndex.swift
@@ -1,0 +1,45 @@
+public protocol SQLCreateIndex: SQLSerializable {
+    associatedtype Modifier: SQLIndexModifier
+    associatedtype Identifier: SQLIdentifier
+    associatedtype TableIdentifier: SQLTableIdentifier
+    associatedtype ColumnIdentifier: SQLColumnIdentifier
+    
+    static func createIndex(_ identifier: Identifier, _ table: TableIdentifier, _ columns: [ColumnIdentifier]) -> Self
+    
+    var modifier: Modifier? { get set }
+}
+
+public struct GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier, ColumnIdentifier>: SQLCreateIndex where
+    Modifier: SQLIndexModifier, Identifier: SQLIdentifier, TableIdentifier: SQLTableIdentifier, ColumnIdentifier: SQLColumnIdentifier
+{
+    public typealias `Self` = GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier, ColumnIdentifier>
+    
+    /// See `SQLCreateIndex`.
+    public static func createIndex(_ identifier: Identifier, _ table: TableIdentifier, _ columns: [ColumnIdentifier]) -> Self {
+        return .init(modifier: nil, identifier: identifier, table: table, columns: columns)
+    }
+    
+    /// See `SQLCreateIndex`.
+    public var modifier: Modifier?
+    
+    public var identifier: Identifier
+    
+    public var table: TableIdentifier
+    
+    public var columns: [ColumnIdentifier]
+    
+    /// See `SQLSerializable`.
+    public func serialize(_ binds: inout [Encodable]) -> String {
+        var sql: [String] = []
+        sql.append("CREATE")
+        if let modifier = modifier {
+            sql.append(modifier.serialize(&binds))
+        }
+        sql.append("INDEX")
+        sql.append(identifier.serialize(&binds))
+        sql.append("ON")
+        sql.append(table.serialize(&binds))
+        sql.append("(" + columns.serialize(&binds) + ")")
+        return sql.joined(separator: " ")
+    }
+}

--- a/Sources/SQL/SQLCreateIndex.swift
+++ b/Sources/SQL/SQLCreateIndex.swift
@@ -2,20 +2,19 @@ public protocol SQLCreateIndex: SQLSerializable {
     associatedtype Modifier: SQLIndexModifier
     associatedtype Identifier: SQLIdentifier
     associatedtype TableIdentifier: SQLTableIdentifier
-    associatedtype ColumnIdentifier: SQLColumnIdentifier
     
-    static func createIndex(_ identifier: Identifier, _ table: TableIdentifier, _ columns: [ColumnIdentifier]) -> Self
+    static func createIndex(_ identifier: Identifier, _ table: TableIdentifier, _ columns: [Identifier]) -> Self
     
     var modifier: Modifier? { get set }
 }
 
-public struct GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier, ColumnIdentifier>: SQLCreateIndex where
-    Modifier: SQLIndexModifier, Identifier: SQLIdentifier, TableIdentifier: SQLTableIdentifier, ColumnIdentifier: SQLColumnIdentifier
+public struct GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier>: SQLCreateIndex where
+    Modifier: SQLIndexModifier, Identifier: SQLIdentifier, TableIdentifier: SQLTableIdentifier
 {
-    public typealias `Self` = GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier, ColumnIdentifier>
+    public typealias `Self` = GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier>
     
     /// See `SQLCreateIndex`.
-    public static func createIndex(_ identifier: Identifier, _ table: TableIdentifier, _ columns: [ColumnIdentifier]) -> Self {
+    public static func createIndex(_ identifier: Identifier, _ table: TableIdentifier, _ columns: [Identifier]) -> Self {
         return .init(modifier: nil, identifier: identifier, table: table, columns: columns)
     }
     
@@ -26,7 +25,7 @@ public struct GenericSQLCreateIndex<Modifier, Identifier, TableIdentifier, Colum
     
     public var table: TableIdentifier
     
-    public var columns: [ColumnIdentifier]
+    public var columns: [Identifier]
     
     /// See `SQLSerializable`.
     public func serialize(_ binds: inout [Encodable]) -> String {

--- a/Sources/SQL/SQLCreateIndexBuilder.swift
+++ b/Sources/SQL/SQLCreateIndexBuilder.swift
@@ -1,0 +1,80 @@
+public final class SQLCreateIndexBuilder<Connection>: SQLQueryBuilder
+    where Connection: DatabaseQueryable, Connection.Query: SQLQuery
+{
+    /// See `SQLColumnBuilder`.
+    public typealias ColumnDefinition = Connection.Query.AlterTable.ColumnDefinition
+    
+    /// `AlterTable` query being built.
+    public var createIndex: Connection.Query.CreateIndex
+    
+    /// See `SQLQueryBuilder`.
+    public var connection: Connection
+    
+    /// See `SQLQueryBuilder`.
+    public var query: Connection.Query {
+        return .createIndex(createIndex)
+    }
+    
+    public func unique() -> Self {
+        createIndex.modifier = .unique
+        return self
+    }
+    
+    /// Creates a new `SQLCreateIndexBuilder`.
+    public init(_ createIndex: Connection.Query.CreateIndex, on connection: Connection) {
+        self.createIndex = createIndex
+        self.connection = connection
+    }
+}
+
+// MARK: Connection
+
+extension DatabaseQueryable where Query: SQLQuery {
+    /// Creates a new `SQLCreateIndexBuilder`.
+    ///
+    ///     conn.create(index: "foo", on: \Planet.name)...
+    ///
+    /// - parameters:
+    ///     - table: Table to create index on.
+    /// - returns: `SQLCreateIndexBuilder`.
+    public func create<T, A>(
+        index identifier: Query.CreateIndex.Identifier,
+        on column: KeyPath<T, A>
+    ) -> SQLCreateIndexBuilder<Self>
+        where T: SQLTable
+    {
+        return .init(.createIndex(identifier, .table(T.self), [.keyPath(column)]), on: self)
+    }
+    
+    /// Creates a new `SQLCreateIndexBuilder`.
+    ///
+    ///     conn.create(index: "foo", on: \Planet.name, \Planet.id)...
+    ///
+    /// - parameters:
+    ///     - table: Table to create index on.
+    /// - returns: `SQLCreateIndexBuilder`.
+    public func create<T, A, B>(
+        index identifier: Query.CreateIndex.Identifier,
+        on a: KeyPath<T, A>, _ b: KeyPath<T, B>
+    ) -> SQLCreateIndexBuilder<Self>
+        where T: SQLTable
+    {
+        return .init(.createIndex(identifier, .table(T.self), [.keyPath(a), .keyPath(b)]), on: self)
+    }
+    
+    /// Creates a new `SQLCreateIndexBuilder`.
+    ///
+    ///     conn.create(index: "foo", on: \Planet.name, \Planet.id, \Planet.galaxyID)...
+    ///
+    /// - parameters:
+    ///     - table: Table to create index on.
+    /// - returns: `SQLCreateIndexBuilder`.
+    public func create<T, A, B, C>(
+        index identifier: Query.CreateIndex.Identifier,
+        on a: KeyPath<T, A>, _ b: KeyPath<T, B>, _ c: KeyPath<T, C>
+    ) -> SQLCreateIndexBuilder<Self>
+        where T: SQLTable
+    {
+        return .init(.createIndex(identifier, .table(T.self), [.keyPath(a), .keyPath(b), .keyPath(c)]), on: self)
+    }
+}

--- a/Sources/SQL/SQLDropIndex.swift
+++ b/Sources/SQL/SQLDropIndex.swift
@@ -1,0 +1,4 @@
+public protocol SQLDropIndex: SQLSerializable { }
+
+// No generic drop index since there is not a standard subset of this query type
+// MySQL requires a table name to drop and other SQLs cannot have a table name passed

--- a/Sources/SQL/SQLIndexModifier.swift
+++ b/Sources/SQL/SQLIndexModifier.swift
@@ -1,0 +1,19 @@
+public protocol SQLIndexModifier: SQLSerializable {
+    static var unique: Self { get }
+}
+
+public enum GenericSQLIndexModifier: SQLIndexModifier {
+    /// See `SQLIndexModifier`.
+    public static var unique: GenericSQLIndexModifier {
+        return ._unique
+    }
+    
+    case _unique
+    
+    /// See `SQLSerializable`.
+    public func serialize(_ binds: inout [Encodable]) -> String {
+        switch self {
+        case ._unique: return "UNIQUE"
+        }
+    }
+}

--- a/Sources/SQL/SQLQuery.swift
+++ b/Sources/SQL/SQLQuery.swift
@@ -1,15 +1,19 @@
 public protocol SQLQuery: SQLSerializable {
     associatedtype AlterTable: SQLAlterTable
+    associatedtype CreateIndex: SQLCreateIndex
     associatedtype CreateTable: SQLCreateTable
     associatedtype Delete: SQLDelete
+    associatedtype DropIndex: SQLDropIndex
     associatedtype DropTable: SQLDropTable
     associatedtype Insert: SQLInsert
     associatedtype Select: SQLSelect
     associatedtype Update: SQLUpdate
 
     static func alterTable(_ alterTable: AlterTable) -> Self
+    static func createIndex(_ createIndex: CreateIndex) -> Self
     static func createTable(_ createTable: CreateTable) -> Self
-    static func delete(_ delete: Delete) -> Self 
+    static func delete(_ delete: Delete) -> Self
+    static func dropIndex(_ dropIndex: DropIndex) -> Self
     static func dropTable(_ dropTable: DropTable) -> Self
     static func insert(_ insert: Insert) -> Self
     static func select(_ select: Select) -> Self

--- a/Sources/SQL/SQLTableIdentifier.swift
+++ b/Sources/SQL/SQLTableIdentifier.swift
@@ -8,7 +8,7 @@ public protocol SQLTableIdentifier: SQLSerializable {
 // MARK: Convenience
 
 extension SQLTableIdentifier {
-    static func table<Table>(_ table: Table.Type) -> Self
+    public static func table<Table>(_ table: Table.Type) -> Self
         where Table: SQLTable
     {
         return .table(.identifier(Table.sqlTableIdentifierString))

--- a/Sources/SQLBenchmark/SQLBenchmark+TestPlanets.swift
+++ b/Sources/SQLBenchmark/SQLBenchmark+TestPlanets.swift
@@ -13,6 +13,7 @@ extension SQLBenchmarker {
             .column(for: \Galaxy.id, .primaryKey)
             .column(for: \Galaxy.name)
             .run().wait()
+        
         try conn.create(table: Planet.self)
             .ifNotExists()
             .column(for: \Planet.id, .primaryKey)
@@ -21,6 +22,10 @@ extension SQLBenchmarker {
         
         try conn.alter(table: Planet.self)
             .column(for: \Planet.name, .default(.literal(.string("Unamed Planet"))))
+            .run().wait()
+        
+        try conn.create(index: .identifier("test_index"), on: \Planet.name)
+            .unique()
             .run().wait()
         
         try conn.insert(into: Galaxy.self)


### PR DESCRIPTION
Adds `SQLCreateIndex` and `SQLDropIndex` protocols (and subprotocols).

Related to https://github.com/vapor/fluent/issues/515.