### PR TITLE
additional convenience methods 1

### DIFF
--- a/Sources/SQL/Operators.swift
+++ b/Sources/SQL/Operators.swift
@@ -1,0 +1,102 @@
+// MARK: KeyPath to Value
+
+public func == <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
+    where T: SQLTable, V: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) == .bind(rhs)
+}
+
+public func != <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
+    where T: SQLTable, V: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) != .bind(rhs)
+}
+
+public func < <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
+    where T: SQLTable, V: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) < .bind(rhs)
+}
+
+public func > <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
+    where T: SQLTable, V: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) > .bind(rhs)
+}
+
+public func <= <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
+    where T: SQLTable, V: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) <= .bind(rhs)
+}
+
+public func >= <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
+    where T: SQLTable, V: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) >= .bind(rhs)
+}
+
+// MARK: KeyPath to KeyPath
+
+
+public func == <A,B,C,D,E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
+    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) == .keyPath(rhs)
+}
+
+public func != <A,B,C,D,E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
+    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) != .keyPath(rhs)
+}
+
+public func > <A,B,C,D,E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
+    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) > .keyPath(rhs)
+}
+
+public func < <A,B,C,D,E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
+    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) < .keyPath(rhs)
+}
+
+public func <= <A,B,C,D,E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
+    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) <= .keyPath(rhs)
+}
+
+public func >= <A,B,C,D,E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
+    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
+{
+    return .keyPath(lhs) >= .keyPath(rhs)
+}
+
+// MARK: Expression to Expression
+
+public func == <E>(_ lhs: E, _ rhs: E) -> E where E: SQLExpression {
+    return E.binary(lhs, .equal, rhs)
+}
+
+public func != <E>(_ lhs: E, _ rhs: E) -> E where E: SQLExpression {
+    return E.binary(lhs, .notEqual, rhs)
+}
+
+public func < <E>(_ lhs: E, _ rhs: E) -> E where E: SQLExpression {
+    return E.binary(lhs, .lessThan, rhs)
+}
+
+public func > <E>(_ lhs: E, _ rhs: E) -> E where E: SQLExpression {
+    return E.binary(lhs, .greaterThan, rhs)
+}
+
+public func <= <E>(_ lhs: E, _ rhs: E) -> E where E: SQLExpression {
+    return E.binary(lhs, .lessThanOrEqual, rhs)
+}
+
+public func >= <E>(_ lhs: E, _ rhs: E) -> E where E: SQLExpression {
+    return E.binary(lhs, .greaterThanOrEqual, rhs)
+}

--- a/Sources/SQL/SQLBinaryOperator.swift
+++ b/Sources/SQL/SQLBinaryOperator.swift
@@ -10,6 +10,8 @@ public protocol SQLBinaryOperator: SQLSerializable {
     static var `notIn`: Self { get }
     static var and: Self { get }
     static var or: Self { get }
+    static var regexp: Self { get }
+    static var notRegexp: Self { get }
 }
 
 // MARK: Generic
@@ -47,6 +49,12 @@ public enum GenericSQLBinaryOperator: SQLBinaryOperator, Equatable {
     
     /// See `SQLBinaryOperator`.
     public static var or: GenericSQLBinaryOperator { return ._or }
+    
+    /// See `SQLBinaryOperator`.
+    public static var regexp: GenericSQLBinaryOperator { return ._regexp }
+    
+    /// See `SQLBinaryOperator`.
+    public static var notRegexp: GenericSQLBinaryOperator { return ._notRegexp }
     
     /// `||`
     case _concatenate
@@ -172,42 +180,5 @@ public enum GenericSQLBinaryOperator: SQLBinaryOperator, Equatable {
         case ._notMatch: return "NOT MATCH"
         case ._notRegexp: return "NOT REGEXP"
         }
-    }
-}
-
-// MARK: Operator
-
-public func == <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
-    where T: SQLTable, V: Encodable, E: SQLExpression
-{
-    if rhs.isNil {
-        return E.binary(.column(.keyPath(lhs)), .equal, .literal(.null))
-    }
-    return E.binary(.column(.keyPath(lhs)), .equal, .bind(.encodable(rhs)))
-}
-
-public func != <T,V,E>(_ lhs: KeyPath<T, V>, _ rhs: V) -> E
-    where T: SQLTable, V: Encodable, E: SQLExpression
-{
-    if rhs.isNil {
-        return E.binary(.column(.keyPath(lhs)), .notEqual, .literal(.null))
-    }
-    return E.binary(.column(.keyPath(lhs)), .notEqual, .bind(.encodable(rhs)))
-}
-
-
-public func == <A, B, C, D, E>(_ lhs: KeyPath<A, B>, _ rhs: KeyPath<C, D>) -> E
-    where A: SQLTable, B: Encodable, C: SQLTable, D: Encodable, E: SQLExpression
-{
-    return E.binary(.column(.keyPath(lhs)), .equal, .column(.keyPath(rhs)))
-}
-
-internal extension Encodable {
-    /// Returns `true` if this `Encodable` is `nil`.
-    var isNil: Bool {
-        guard let optional = self as? AnyOptionalType, optional.anyWrapped == nil else {
-            return false
-        }
-        return true
     }
 }

--- a/Sources/SQL/SQLBind.swift
+++ b/Sources/SQL/SQLBind.swift
@@ -1,6 +1,8 @@
 public protocol SQLBind: SQLSerializable {
     static func encodable<E>(_ value: E) -> Self
         where E: Encodable
+    
+    var value: Encodable { get }
 }
 
 // MARK: Generic

--- a/Sources/SQL/SQLColumnIdentifier.swift
+++ b/Sources/SQL/SQLColumnIdentifier.swift
@@ -10,7 +10,6 @@ public protocol SQLColumnIdentifier: SQLSerializable {
 
 // MARK: Convenience
 
-
 extension SQLColumnIdentifier {
     public static func keyPath<T,V>(_ keyPath: KeyPath<T, V>) -> Self where T: SQLTable {
         guard let property = try! T.reflectProperty(forKey: keyPath) else {

--- a/Sources/SQL/SQLQueryBuilder.swift
+++ b/Sources/SQL/SQLQueryBuilder.swift
@@ -25,6 +25,8 @@ extension SQLQueryFetcher {
     public func run(_ handler: @escaping (Connection.Output) throws -> ()) -> Future<Void> {
         return connection.query(query, handler)
     }
+    
+    
 }
 
 public protocol SQLConnection: DatabaseQueryable where Query: SQLQuery {
@@ -34,6 +36,24 @@ public protocol SQLConnection: DatabaseQueryable where Query: SQLQuery {
 
 extension SQLQueryFetcher where Connection: SQLConnection {
     // MARK: Decode
+    
+    public func first<D>(decoding type: D.Type) -> Future<D?>
+        where D: Decodable
+    {
+        return self.all(decoding: type).map { $0.first }
+    }
+    
+    public func first<A, B>(decoding a: A.Type, _ b: B.Type) -> Future<(A, B)?>
+        where A: SQLTable, B: SQLTable
+    {
+        return self.all(decoding: a, b).map { $0.first }
+    }
+    
+    public func first<A, B, C>(decoding a: A.Type, _ b: B.Type, _ c: C.Type) -> Future<(A, B, C)?>
+        where A: SQLTable, B: SQLTable, C: SQLTable
+    {
+        return self.all(decoding: a, b, c).map { $0.first }
+    }
     
     public func all<D>(decoding type: D.Type) -> Future<[D]>
         where D: Decodable

--- a/Sources/SQL/SQLSelectBuilder.swift
+++ b/Sources/SQL/SQLSelectBuilder.swift
@@ -25,15 +25,7 @@ public final class SQLSelectBuilder<Connection>: SQLQueryFetcher, SQLPredicateBu
     }
     
     public func column(
-        function: String,
-        _ arguments: Connection.Query.Select.SelectExpression.Expression.Function.Argument...,
-        as alias: Connection.Query.Select.SelectExpression.Identifier? = nil
-    ) -> Self {
-        return column(expression: .function(.function(function, arguments)), as: alias)
-    }
-    
-    public func column(
-        expression: Connection.Query.Select.SelectExpression.Expression,
+        _ expression: Connection.Query.Select.SelectExpression.Expression,
         as alias: Connection.Query.Select.SelectExpression.Identifier? = nil
     ) -> Self {
         return column(.expression(expression, alias: alias))
@@ -112,6 +104,82 @@ public final class SQLSelectBuilder<Connection>: SQLQueryFetcher, SQLPredicateBu
     public func orderBy(_ expression: Connection.Query.Select.OrderBy.Expression, _ direction: Connection.Query.Select.OrderBy.Direction = .ascending) -> Self {
         select.orderBy.append(.orderBy(expression, direction))
         return self
+    }
+}
+
+// MARK: Columns
+
+extension SQLSelectBuilder {
+    public func column<T, V>(
+        _ keyPath: KeyPath<T, V>,
+        as alias: Connection.Query.Select.SelectExpression.Identifier? = nil
+    ) -> Self where T: SQLTable {
+        return self.column(.expression(.column(.keyPath(keyPath)), alias: alias))
+    }
+    
+    public func columns<T1, V1, T2, V2>(
+        _ keyPath1: KeyPath<T1, V1>, as alias1: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath2: KeyPath<T2, V2>, as alias2: Connection.Query.Select.SelectExpression.Identifier? = nil
+    ) -> Self where T1: SQLTable, T2: SQLTable {
+        return self
+            .column(.expression(.column(.keyPath(keyPath1)), alias: alias1))
+            .column(.expression(.column(.keyPath(keyPath2)), alias: alias2))
+    }
+    
+    public func columns<T1, V1, T2, V2, T3, V3>(
+        _ keyPath1: KeyPath<T1, V1>, as alias1: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath2: KeyPath<T2, V2>, as alias2: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath3: KeyPath<T3, V3>, as alias3: Connection.Query.Select.SelectExpression.Identifier? = nil
+    ) -> Self where T1: SQLTable, T2: SQLTable, T3: SQLTable {
+        return self
+            .column(.expression(.column(.keyPath(keyPath1)), alias: alias1))
+            .column(.expression(.column(.keyPath(keyPath2)), alias: alias2))
+            .column(.expression(.column(.keyPath(keyPath3)), alias: alias3))
+    }
+    
+    public func columns<T1, V1, T2, V2, T3, V3, T4, V4>(
+        _ keyPath1: KeyPath<T1, V1>, as alias1: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath2: KeyPath<T2, V2>, as alias2: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath3: KeyPath<T3, V3>, as alias3: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath4: KeyPath<T4, V4>, as alias4: Connection.Query.Select.SelectExpression.Identifier? = nil
+    ) -> Self where T1: SQLTable, T2: SQLTable, T3: SQLTable, T4: SQLTable {
+        return self
+            .column(.expression(.column(.keyPath(keyPath1)), alias: alias1))
+            .column(.expression(.column(.keyPath(keyPath2)), alias: alias2))
+            .column(.expression(.column(.keyPath(keyPath3)), alias: alias3))
+            .column(.expression(.column(.keyPath(keyPath4)), alias: alias4))
+    }
+    
+    public func columns<T1, V1, T2, V2, T3, V3, T4, V4, T5, V5>(
+        _ keyPath1: KeyPath<T1, V1>, as alias1: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath2: KeyPath<T2, V2>, as alias2: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath3: KeyPath<T3, V3>, as alias3: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath4: KeyPath<T4, V4>, as alias4: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath5: KeyPath<T5, V5>, as alias5: Connection.Query.Select.SelectExpression.Identifier? = nil
+    ) -> Self where T1: SQLTable, T2: SQLTable, T3: SQLTable, T4: SQLTable, T5: SQLTable {
+        return self
+            .column(.expression(.column(.keyPath(keyPath1)), alias: alias1))
+            .column(.expression(.column(.keyPath(keyPath2)), alias: alias2))
+            .column(.expression(.column(.keyPath(keyPath3)), alias: alias3))
+            .column(.expression(.column(.keyPath(keyPath4)), alias: alias4))
+            .column(.expression(.column(.keyPath(keyPath5)), alias: alias5))
+    }
+    
+    public func columns<T1, V1, T2, V2, T3, V3, T4, V4, T5, V5, T6, V6>(
+        _ keyPath1: KeyPath<T1, V1>, as alias1: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath2: KeyPath<T2, V2>, as alias2: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath3: KeyPath<T3, V3>, as alias3: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath4: KeyPath<T4, V4>, as alias4: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath5: KeyPath<T5, V5>, as alias5: Connection.Query.Select.SelectExpression.Identifier? = nil,
+        _ keyPath6: KeyPath<T6, V6>, as alias6: Connection.Query.Select.SelectExpression.Identifier? = nil
+    ) -> Self where T1: SQLTable, T2: SQLTable, T3: SQLTable, T4: SQLTable, T5: SQLTable, T6: SQLTable {
+        return self
+            .column(.expression(.column(.keyPath(keyPath1)), alias: alias1))
+            .column(.expression(.column(.keyPath(keyPath2)), alias: alias2))
+            .column(.expression(.column(.keyPath(keyPath3)), alias: alias3))
+            .column(.expression(.column(.keyPath(keyPath4)), alias: alias4))
+            .column(.expression(.column(.keyPath(keyPath5)), alias: alias5))
+            .column(.expression(.column(.keyPath(keyPath6)), alias: alias6))
     }
 }
 


### PR DESCRIPTION
Adds a bunch of conveniences including
- Operators for:
    - KeyPath to Value
    - KeyPath to KeyPath
    - Expression to Expression
- Columns overloads for SelectBuilder
- Function conveniences for expression
- Regexp on BinaryOperator
- `first()` on query fetchers
- Better `IS NULL` support.
