### PR TITLE
Add an SQLError type

### DIFF
--- a/Sources/SQL/SQLError.swift
+++ b/Sources/SQL/SQLError.swift
@@ -1,0 +1,78 @@
+public struct SQLError: Debuggable {
+  public let type: SQLErrorType
+  public var reason: String
+  public var location: SourceLocation?
+  public var stackTrace: [String]
+
+  public var identifier: String {
+    return "SQLError(\(self.type.description))"
+  }
+
+  init(type: SQLErrorType, reason: String, location: SourceLocation) {
+    self.type = type
+    self.reason = reason
+    self.location = location
+    self.stackTrace = SQLError.makeStackTrace()
+  }
+}
+
+public enum SQLErrorType: CustomStringConvertible {
+  /// Generic error case, for errors that does not match
+  /// any other category
+  case unknown
+  /// Internal error of the DB server
+  case intern
+  /// Permission to perform the operation was denied
+  /// by the server
+  case permission
+  /// Operation was aborted
+  case abort
+  /// Another operation performed on another connection is
+  /// conflicting with the requested operation
+  case busy
+  /// The operation alters an entry that has been locked by
+  /// another connection
+  case locked
+  /// The database server could not allocate memory
+  case memory
+  /// The database is readonly
+  case readOnly
+  /// The database server could not read or write to disk,
+  /// or to open a file
+  case ioError
+  /// A constraint failed to be applied
+  case constraint(name: String)
+  /// A data type does not match with the expected one
+  case typeMismatch
+  /// A table of column name was not recognized
+  case unknownEntity(name: String)
+  
+  public var description: String {
+    switch self {
+    case .unknown:
+      return "Unknown error"
+    case .intern:
+      return "Internal error"
+    case .permission:
+      return "Permission denied"
+    case .abort:
+      return "Operation aborted"
+    case .busy:
+      return "Database is busy"
+    case .locked:
+      return "Trying to access locked resources"
+    case .memory:
+      return "Datbase could not allocate memory"
+    case .readOnly:
+      return "Database is read only"
+    case .ioError:
+      return "Database failed to read or write data to disk"
+    case .constraint(let name):
+      return "Constraint \(name) failed"
+    case .typeMismatch:
+      return "Type of data does not match expectation"
+    case .unknownEntity(let name):
+      return "Entity \(name) is not known"
+    }
+  }
+}


### PR DESCRIPTION
## Global idea
The proposal of that pull request is to create a protocol and an enum to unify the error handling of all SQL drivers.
Here are the base ideas: 
- native SQL error types can create a custom error type that conform to the **SQLError** protocol, and that contains DB specific properties
- the **SQLErrorType** enum lists a variety of type of errors. It does not exactly match the list of error codes of the databases, but makes it possible to implement different behaviors depending on the error, without having to write DB-specific code.

As of today, SQLite has an enum similar to SQLErrorType, but not other drivers. But even for SQLite, this enum is internal, and thus cannot be used in the client application.

## Things that I would like to discuss
### The granularity of the SQLErrorType enum
I have the feeling it could be less granular : some error like ioError and memory points are related to the configuration of the database server. some others like invalidData are related to the data.
In the first case, the problem is not related to the application, but rather to the system.
In the second case, the problem is related to the application.
So maybe that would be a more useful level of granularity that what is proposed here.

### Adding valuable informations to the errors
For exemple, in the case of the constraint error, the name of the constraint as a payload of the error type could be valuable to the developper. Maybe the type of constraint (unique, foreign key, ...) could also be.
What would you think about adding such data ?

## Additional notes
Please find here an exemple integration in the SQLite driver : https://github.com/jduquennoy/sqlite/commit/29dcb513c1d9bc0a4dd3c97ff8003928f6a39f55