### PR TITLE
sql 2.0.0 release

### DIFF
--- a/Sources/SQL/SQLColumnConstraint.swift
+++ b/Sources/SQL/SQLColumnConstraint.swift
@@ -121,7 +121,6 @@ extension SQLColumnConstraint {
     }
 }
 
-
 // MARK: Generic
 
 /// Generic implementation of `SQLColumnConstraint`.


### PR DESCRIPTION
vapor/sql rewrite:
- `SQLQuery` is now completely protocolized
- specific components (such as SQLBind) can be overridden with concrete components as desired for custom behavior
- most protocols have `Generic...` concrete types supplied by this package that conform to standard SQL
- no more generic serializers, each type is `SQLSerializable` and worries about serializing itself.