### PR TITLE
Wrap binary op lhs/rhs in parentheses

### DIFF
--- a/Sources/SQL/SQLExpression.swift
+++ b/Sources/SQL/SQLExpression.swift
@@ -278,7 +278,7 @@ public indirect enum GenericSQLExpression<Literal, Bind, ColumnIdentifier, Binar
                 }
             default: break
             }
-            return lhs.serialize(&binds) + " " + op.serialize(&binds) + " " + rhs.serialize(&binds)
+            return "(" + lhs.serialize(&binds) + ") " + op.serialize(&binds) + " (" + rhs.serialize(&binds) + ")"
         case ._function(let function): return function.serialize(&binds)
         case ._group(let group):
             return "(" + group.map { $0.serialize(&binds) }.joined(separator: ", ") + ")"


### PR DESCRIPTION
This makes the SQL behave more like it looks in Swift.

`.binary(lhs, .ilike, rhs)` looks like lhs and rhs will be computed
as `(lhs) ILIKE (rhs)`, which is not always the case when rhs is itself
an expression with an operator that does not take precedence.

This will only have an effect in advanced queries with precedence that's
hard to follow, but is the simplest solution, seeing that Vapor/SQL
has no option to wrap arbitrary expressions in parentheses.